### PR TITLE
v0.1.0-alpha.0

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -50,8 +50,8 @@ The RAG (Retrieval-Augmented Generation) Platform Kit is a production-ready micr
 ## Quick Start Guide
 
 ### Prerequisites
-- Python 3.9+
-- pip
+- Python 3.12
+- Docker & Docker Compose (optional for e2e)
 - Git
 
 ### Step 1: Clone and Setup
@@ -60,11 +60,11 @@ The RAG (Retrieval-Augmented Generation) Platform Kit is a production-ready micr
 git clone <your-repo-url>
 cd rag-platform-kit
 
-# Create virtual environment
-python3 -m venv renv
+# Create virtual environment (Python 3.12)
+python3.12 -m venv venvpy312
 
 # Activate virtual environment
-source renv/bin/activate  # On Windows: renv\Scripts\activate
+source venvpy312/bin/activate  # On Windows: venvpy312\Scripts\activate
 
 # Install dependencies
 pip install -r requirements.txt
@@ -103,8 +103,8 @@ REDIS_URL=redis://localhost:6379
 # Start the service
 uvicorn app.main:app --host 0.0.0.0 --port 8000 --reload
 
-# Or using Python directly
-python app/main.py
+# Or using helper script
+bash utilscripts/quick_start.sh start
 ```
 
 ### Step 4: Verify Installation
@@ -420,6 +420,12 @@ pytest --cov=app --cov-report=html
 pytest tests/unit/          # Unit tests
 pytest tests/integration/   # Integration tests
 pytest tests/e2e/           # End-to-end tests
+
+### E2E (black-box) runner
+
+```bash
+bash utilscripts/e2e_run.sh
+```
 ```
 
 ### Test Endpoints Manually
@@ -565,12 +571,3 @@ df -h
 3. Make your changes
 4. Add tests for new functionality
 5. Submit a pull request
-
-### License
-This project is licensed under the MIT License - see the LICENSE file for details.
-
----
-
-**Last Updated**: January 2024  
-**Version**: 1.0.0  
-**Maintainer**: Your Team

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,14 +34,23 @@ pytest tests/unit/          # Unit tests only
 pytest tests/integration/   # Integration tests only
 ```
 
-### 3. E2E tests
+### 3. E2E tests (black-box)
 
-Run the containerized end-to-end suite (requires Docker):
+Runs against live infra (Qdrant, Redis, Ollama) via docker compose. The API runs locally (not in Docker) for true black-box testing.
 
 ```bash
-bash scripts/e2e_up.sh
+# One-shot runner that starts infra, ensures small Ollama model, starts API, runs tests, then stops infra
+bash utilscripts/e2e_run.sh
+
+# Or manually:
+docker compose -f tests/docker-compose.yml -f tests/docker-compose.test.yml up -d qdrant redis ollama
+export BASE_URL=http://localhost:8000
+python3.12 -m venv venvpy312 && source venvpy312/bin/activate
+pip install -e . && pip install -r tests/requirements-test.txt
+bash utilscripts/quick_start.sh start
 pytest -m e2e -q
-bash scripts/e2e_down.sh
+bash utilscripts/quick_start.sh stop
+docker compose -f tests/docker-compose.yml -f tests/docker-compose.test.yml stop
 ```
 
 ## Test Categories
@@ -108,3 +117,4 @@ pytest tests/unit/test_file_processing.py::TestFileProcessor::test_extract_text_
 # Run with verbose output
 pytest -vvv
 ```
+


### PR DESCRIPTION
### RAG Platform Kit v0.1.0-alpha.0 – Release Notes

- Overview
  - FastAPI microservice implementing Retrieval-Augmented Generation (RAG): document ingestion → chunking → embedding → vector store → semantic search → LLM generation with retrieved context.

- Key Features
  - Ingestion: Upload PDF/TXT, clean, chunk (sliding window), batch-embed, and store in vector DB.
  - Semantic Search: Vector similarity search with configurable top_k and similarity threshold (with fallback).
  - RAG Generation: Retrieves top-K relevant chunks and calls an LLM with grounded context; returns answer + sources.
  - Pluggable Providers:
    - Embeddings: Sentence-Transformers (local, default), OpenAI (text-embedding-*), Cohere (embed-english-*).
    - Vector Stores: ChromaDB (local), Qdrant (HTTP/gRPC), Redis (vector index).
    - LLMs: Ollama (default), OpenAI, Cohere, Hugging Face Transformers.
  - Black-box E2E Tests: Real HTTP tests against infra (Qdrant, Ollama) started via docker compose.
  - Unit and Integration tests for functions used in endpoints
  - CI/CD: GitHub Actions workflow to run the e2e suite; caches Docker images to speed up runs.

- API Endpoints
  - GET /health: Service and platform metadata (vector store, embedding model, llm provider).
  - POST /api/v1/ingest: Multipart upload of PDF/TXT → returns chunks_created and document_id.
  - POST /api/v1/search: Body: { query, top_k, similarity_threshold, filters? } → list of relevant chunks.
  - POST /api/v1/generate: Body: { query, search_params?, context?, temperature, max_tokens } → answer + sources.

- Configuration
  - Env-driven via `app/core/config.py` and `.env`:
    - VECTOR_STORE_TYPE: chroma | qdrant | redis
    - CHROMA_PERSIST_DIRECTORY
    - QDRANT_URL, QDRANT_API_KEY
    - REDIS_URL
    - EMBEDDING_MODEL, EMBEDDING_DIM (default 384)
    - LLM_PROVIDER: ollama | openai | cohere | huggingface
    - OLLAMA_BASE_URL, OLLAMA_MODEL
    - TOP_K, SIMILARITY_THRESHOLD
    - SERVICE_HOST, SERVICE_PORT
  - Defaults: Qdrant at `http://localhost:6333`, Ollama at `http://localhost:11434`, local sentence-transformers.

- Requirements
  - Python 3.12
  - Docker + Docker Compose (for infra/e2e)
  - For OpenAI/Cohere/HF providers, set the relevant API keys in `.env`.

- Quick Start (Service)
  - Local venv (3.12) + run:
    - python3.12 -m venv venvpy312 && source venvpy312/bin/activate
    - pip install -r requirements.txt
    - uvicorn app.main:app --host 0.0.0.0 --port 8000
  - Or use helper:
    - bash utilscripts/quick_start.sh start
    - bash utilscripts/quick_start.sh stop

- Quick Start (Infra + E2E)
  - Start infra + run tests (black-box):
    - bash utilscripts/e2e_run.sh
  - What it does:
    - docker compose up qdrant, redis, ollama (under `tests/`)
    - waits on health (Qdrant, Ollama), ensures a small Ollama model is pulled
    - sets up Python 3.12 venv, installs `tests/requirements-test.txt`
    - starts the API locally, waits for /health
    - runs pytest `-m e2e`
    - stops API and stops containers (keeps them cached for faster re-runs)

- CI/CD
  - `.github/workflows/e2e.yml`:
    - Caches Docker images (Qdrant, Redis, Ollama) between runs.
    - Executes `utilscripts/e2e_run.sh`.
    - On failure, uploads docker compose logs artifact.
    - Tears down infra when finished.
   - `.github/workflows/test.yml`:
    - for unit and integration testing

- Notes and Limitations
  - Default small Ollama model used for CI speed; switch `OLLAMA_MODEL` for higher quality.
  - For OpenAI/Cohere/HF, provide API keys; otherwise the local embedding/LLM options are used.
  - Retrieval applies threshold; if no result passes, it falls back to top results to avoid empty context.


[Project Summary](README.md)
[Documentation](docs/README.md)
[Tests](tests/README.md)
